### PR TITLE
Update 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-# Github Custom Notification Context SCM Behaviour
+# "Github Custom Notification Context SCM Behaviour" Jenkins plugin
 
-Github Branch Source trait to define custom context labels for Github build status notifications.
+This plugin allows defining custom context labels for GitHub build status notifications. This was implemented by Github Branch Source trait.
+
+## How to use this plugin
+
+After installing go to the job configuration. Under "Branch sources" -> "GitHub" -> "Behaviors" click "Add" and select "Custom Github Notification Context" from the dropdown menu. Then you can type your custom context name into the "Label" field.

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
             <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
-    <!-- Assuming you want to host on @jenkinsci:
+
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     </scm>
-    -->
+
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>github-scm-trait-notification-context</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.73.3</jenkins.version>
@@ -28,7 +28,8 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    </scm>
+      <tag>1.0</tag>
+  </scm>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>github-scm-trait-notification-context</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.73.3</jenkins.version>
@@ -28,7 +28,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>1.1</tag>
   </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>github-scm-trait-notification-context</artifactId>
-    <version>1.0</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.73.3</jenkins.version>
@@ -28,7 +28,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>github-scm-trait-notification-context</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.73.3</jenkins.version>
@@ -28,7 +28,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>1.1</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <repositories>


### PR DESCRIPTION
Started by upstream project "node-test-commit" build number 42966
originally caused by:
 Started by upstream project "node-test-pull-request" build number 34953
 originally caused by:
  Started by user Node.js GitHub Bot
Running as SYSTEM
[EnvInject] - Loading node environment variables.
Building remotely on test-packetnet-ubuntu1804-x64-2 (Ubuntu amd64-Ubuntu jenkins-workspace 18.04 amd64-Ubuntu-18.04 Ubuntu-18.04 amd64) in workspace /home/iojs/build/workspace/node-test-commit-arm-fanned@2
The recommended git tool is: NONE
using credential 96d5f81c-e9ad-45f7-ba5d-bc8107c0ae2c
 > git rev-parse --is-inside-work-tree # timeout=10
Fetching changes from the remote Git repository
 > git config remote.origin.url git@github.com:nodejs/node.git # timeout=10
Cleaning workspace
 > git rev-parse --verify HEAD # timeout=10
Resetting working tree
 > git reset --hard # timeout=10
 > git clean -fdx # timeout=10
Fetching upstream changes from git@github.com:nodejs/node.git
 > git --version # timeout=10
 > git --version # 'git version 2.17.1'
using GIT_SSH to set credentials 
 > git fetch --tags --progress -- git@github.com:nodejs/node.git +refs/heads/*:refs/remotes/origin/* +refs/pull/35644/head:refs/remotes/origin/_jenkins_local_branch # timeout=20
 > git rev-parse refs/remotes/origin/_jenkins_local_branch^{commit} # timeout=10
Checking out Revision 7c1d773fc85933beb183487eecc02490e9b47276 (refs/remotes/origin/_jenkins_local_branch)
 > git config core.sparsecheckout # timeout=10
 > git checkout -f 7c1d773fc85933beb183487eecc02490e9b47276 # timeout=10
Commit message: "Update lib/internal/errors.js"
Using 'Changelog to branch' strategy.
Cleaning workspace
 > git rev-parse --verify HEAD # timeout=10
Resetting working tree
 > git reset --hard # timeout=10
 > git clean -fdx # timeout=10
Exporting environment variable NODEJS_VERSION with Node.js version '16.0.0'
Exporting environment variable NODEJS_MAJOR_VERSION with Node.js major version '16'
Exporting parameter NODEJS_VERSION with Node.js version '16.0.0'
Exporting parameter NODEJS_MAJOR_VERSION with Node.js major version '16'
Run condition [And] enabling prebuild for step [MultiJob Phase]
Run condition [Or] enabling prebuild for step [MultiJob Phase]
[node-test-commit-arm-fanned@2] $ /bin/bash -ex /tmp/jenkins6340947547105742349.sh
+ echo
+ '[' -n 7c1d773fc85933beb183487eecc02490e9b47276 ']'
+ TEMP_BRANCH=jenkins-node-test-commit-arm-fanned-7c1d773fc85933beb183487eecc02490e9b47276
+ echo 'Using TEMP_BRANCH name: jenkins-node-test-commit-arm-fanned-7c1d773fc85933beb183487eecc02490e9b47276'
Using TEMP_BRANCH name: jenkins-node-test-commit-arm-fanned-7c1d773fc85933beb183487eecc02490e9b47276
+ echo TEMP_BRANCH=jenkins-node-test-commit-arm-fanned-7c1d773fc85933beb183487eecc02490e9b47276
[EnvInject] - Injecting environment variables from a build step.
[EnvInject] - Injecting as environment variables the properties file path 'env.properties'
[EnvInject] - Variables injected successfully.
Waiting for the completion of git-rebase
git-rebase #72692 started.
git-rebase #72692 completed. Result was SUCCESS
Build step 'Trigger/call builds on other projects' changed build result to SUCCESS
Triggering projects: post-build-status-update
    >> Job status: [node-cross-compile] the 'build only if scm changes' feature is disabled.
Starting build job node-cross-compile.
Finished Build : #32154 of Job : node-cross-compile with status : SUCCESS
    >> Job status: [git-nodesource-update-reference] the 'build only if scm changes' feature is disabled.
Starting build job git-nodesource-update-reference.
Finished Build : #28071 of Job : git-nodesource-update-reference with status : SUCCESS
Variable Existence Condition: checking "NODEJS_MAJOR_VERSION" variable 
Numerical comparison: [16] < Less than [12]
Run condition [And] preventing perform for step [MultiJob Phase]
Variable Existence Condition: checking "NODEJS_MAJOR_VERSION" variable 
Numerical comparison: [16] >= Greater than or equal to [12]
Run condition [Or] enabling perform for step [MultiJob Phase]
    >> Job status: [node-test-binary-arm-12+] the 'build only if scm changes' feature is disabled.
Starting build job node-test-binary-arm-12+.
Finished Build : #8778 of Job : node-test-binary-arm-12+ with status : UNSTABLE
Collecting metadata...
Metadata collection done.
Notifying upstream projects of job completion
Variable Existence Condition: checking "NODEJS_MAJOR_VERSION" variable 
Numerical comparison: [16] < Less than [12]
Run condition [And] preventing perform for step [Builder to mark whether executed]
Variable Existence Condition: checking "NODEJS_MAJOR_VERSION" variable 
Numerical comparison: [16] >= Greater than or equal to [12]
Run condition [Or] enabling perform for step [Builder to mark whether executed]
Finished: UNSTABLE